### PR TITLE
feat(reseller): Implement sales attribution at checkout

### DIFF
--- a/src/main/kotlin/data/model/CheckoutRequest.kt
+++ b/src/main/kotlin/data/model/CheckoutRequest.kt
@@ -5,5 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CheckoutRequest(
     val addressId: String,
-    val couponCode: String? = null
+    val couponCode: String? = null,
+    val resellerSlug: String? = null
 )

--- a/src/main/kotlin/data/model/OrderModels.kt
+++ b/src/main/kotlin/data/model/OrderModels.kt
@@ -32,5 +32,6 @@ data class Order(
     val mpPreferenceId: String? = null,
     val items: List<OrderItem>,
     val couponCode: String? = null,
-    val discountAmount: Double? = null
+    val discountAmount: Double? = null,
+    val resellerId: String? = null
 )

--- a/src/main/kotlin/data/model/ResellerStoreResponse.kt
+++ b/src/main/kotlin/data/model/ResellerStoreResponse.kt
@@ -1,0 +1,15 @@
+package data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the response for a reseller fetching their personal store details.
+ */
+@Serializable
+data class ResellerStoreResponse(
+    val resellerName: String,
+    val uniqueStoreSlug: String,
+    val storeUrl: String, // The full, shareable URL for their store
+    val commissionRate: Double,
+    val isActive: Boolean
+)

--- a/src/main/kotlin/data/model/Tables.kt
+++ b/src/main/kotlin/data/model/Tables.kt
@@ -88,6 +88,7 @@ object OrdersTable : Table("orders") {
     val mpPreferenceId = varchar("mp_preference_id", 255).nullable() // <-- NEW
     val couponCode = varchar("coupon_code", 100).references(CouponsTable.code).nullable()
     val discountAmount = double("discount_amount").nullable()
+    val resellerId = varchar("reseller_id", 128).references(UsersTable.id).nullable()
 
     override val primaryKey = PrimaryKey(id)
 }

--- a/src/main/kotlin/data/repository/OrderRepository.kt
+++ b/src/main/kotlin/data/repository/OrderRepository.kt
@@ -7,18 +7,20 @@ import data.model.Address
 interface OrderRepository {
     /**
      * Creates a new order from the user's cart items, selected shipping address,
-     * and an optional discount coupon.
+     * an optional discount coupon, and an optional reseller attribution.
      * @param userId The ID of the user placing the order.
      * @param cartItems The list of items from the user's shopping cart.
      * @param shippingAddress The user's selected shipping address.
      * @param couponCode The optional coupon code to apply to the order.
+     * @param resellerId The optional ID of the reseller to attribute the sale to.
      * @return The newly created Order.
      */
     suspend fun createOrder(
         userId: String,
         cartItems: List<CartItem>,
         shippingAddress: Address,
-        couponCode: String? // <-- ADD THIS PARAMETER
+        couponCode: String?,
+        resellerId: String? // <-- ADD THIS PARAMETER
     ): Order
 
     /**

--- a/src/main/kotlin/data/repository/OrderRepositoryImpl.kt
+++ b/src/main/kotlin/data/repository/OrderRepositoryImpl.kt
@@ -19,7 +19,8 @@ class OrderRepositoryImpl(
         userId: String,
         cartItems: List<CartItem>,
         shippingAddress: Address,
-        couponCode: String?
+        couponCode: String?,
+        resellerId: String?
     ): Order = dbQuery {
         if (cartItems.isEmpty()) throw BadRequestException("Cannot create an order from an empty cart.")
 
@@ -83,6 +84,7 @@ class OrderRepositoryImpl(
             it[this.shippingAddress] = shippingAddress
             it[this.couponCode] = validatedCoupon?.code
             it[this.discountAmount] = discountAmount
+            it[this.resellerId] = resellerId
         }
 
         validatedCoupon?.let { coupon ->
@@ -126,7 +128,8 @@ class OrderRepositoryImpl(
             mpPreferenceId = null,
             items = orderItems,
             couponCode = validatedCoupon?.code,
-            discountAmount = discountAmount
+            discountAmount = discountAmount,
+            resellerId = resellerId
         )
     }
 
@@ -166,7 +169,8 @@ class OrderRepositoryImpl(
             mpPreferenceId = row[OrdersTable.mpPreferenceId],
             items = items,
             couponCode = row[OrdersTable.couponCode],
-            discountAmount = row[OrdersTable.discountAmount]
+            discountAmount = row[OrdersTable.discountAmount],
+            resellerId = row[OrdersTable.resellerId]
         )
     }
 

--- a/src/main/kotlin/data/repository/ResellerRepository.kt
+++ b/src/main/kotlin/data/repository/ResellerRepository.kt
@@ -34,4 +34,11 @@ interface ResellerRepository {
      * @return True if the deletion was successful, false otherwise.
      */
     suspend fun deleteReseller(userId: String): Boolean // <-- ADD THIS
+
+    /**
+     * Finds an active reseller by their unique store slug.
+     * @return The User object, or null if no active reseller is found with that slug.
+     */
+    suspend fun findActiveResellerBySlug(slug: String): User? // <-- ADD THIS
+
 }

--- a/src/main/resources/db/migration/V11__Add_Reseller_Attribution_To_Orders.sql
+++ b/src/main/resources/db/migration/V11__Add_Reseller_Attribution_To_Orders.sql
@@ -1,0 +1,8 @@
+-- V11__Add_Reseller_Attribution_To_Orders.sql
+-- Adds a column to the orders table to link a sale to a specific reseller.
+
+ALTER TABLE orders
+    ADD COLUMN reseller_id VARCHAR(128) REFERENCES users(id) ON DELETE SET NULL;
+
+-- An index on this new column will be useful for quickly finding all orders for a reseller.
+CREATE INDEX idx_orders_reseller_id ON orders(reseller_id);

--- a/src/main/resources/db/migration/V9__Alter_Photo_Urls_Column_Type.sql
+++ b/src/main/resources/db/migration/V9__Alter_Photo_Urls_Column_Type.sql
@@ -1,0 +1,7 @@
+-- V9__Alter_Photo_Urls_Column_Type.sql
+-- Alters the photo_urls column in the product_reviews table from a text array (TEXT[])
+-- to a simple TEXT type. This aligns the schema with the application's method
+-- of storing the URLs as a single, comma-separated string.
+
+ALTER TABLE product_reviews
+    ALTER COLUMN photo_urls TYPE TEXT;


### PR DESCRIPTION
This commit enables the core sales attribution functionality for the Phase 3 reseller platform. The checkout process is now capable of receiving a reseller's unique store slug and linking the resulting order to that reseller.

Key changes include:

- **Database & Schema:**
  - Adds a `reseller_id` foreign key to the `orders` table via the `V11__...` migration to create the link between a sale and a reseller.

- **API & Data Models:**
  - The `CheckoutRequest` DTO is updated to include an optional `resellerSlug`.
  - The `POST /orders/checkout` endpoint in `orderRouting.kt` now uses the `ResellerRepository` to validate the slug and pass the corresponding `resellerId` to the order creation logic.

- **Repository Layer:**
  - The `OrderRepository` interface and implementation have been updated; the `createOrder` method now accepts and persists the `resellerId`.
  - A new `findActiveResellerBySlug` method was added to `ResellerRepository` to facilitate the lookup during checkout.