### PR TITLE
feat(reseller): Implement commission dashboard

### DIFF
--- a/src/main/kotlin/data/model/ResellerDashboardResponse.kt
+++ b/src/main/kotlin/data/model/ResellerDashboardResponse.kt
@@ -1,0 +1,33 @@
+package data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A summary of a reseller's most recent orders for their dashboard.
+ */
+@Serializable
+data class SimpleOrderSummary(
+    val orderId: String,
+    val orderDate: Long,
+    val orderTotal: Double,
+    val commissionEarned: Double,
+    val status: String
+)
+
+/**
+ * Represents the data structure for the reseller's main dashboard.
+ */
+@Serializable
+data class ResellerDashboardResponse(
+    // Lifetime stats
+    val totalSalesValue: Double,
+    val totalCommissionEarned: Double,
+    val attributedOrderCount: Int,
+
+    // Current month stats
+    val salesInCurrentMonth: Double,
+    val commissionInCurrentMonth: Double,
+
+    // A quick look at recent activity
+    val recentOrders: List<SimpleOrderSummary>
+)

--- a/src/main/kotlin/data/repository/ResellerRepository.kt
+++ b/src/main/kotlin/data/repository/ResellerRepository.kt
@@ -2,6 +2,7 @@ package data.repository
 
 import com.example.data.model.User
 import data.model.ResellerCreateRequest
+import data.model.ResellerDashboardResponse
 import data.model.ResellerUpdateRequest
 
 interface ResellerRepository {
@@ -20,25 +21,30 @@ interface ResellerRepository {
      * Finds a single reseller by their user ID.
      * @return The User object with their reseller profile, or null if not found.
      */
-    suspend fun findResellerById(userId: String): User? // <-- ADD THIS
+    suspend fun findResellerById(userId: String): User?
 
     /**
      * Updates a reseller's profile information.
      * @return True if the update was successful, false otherwise.
      */
-    suspend fun updateReseller(userId: String, request: ResellerUpdateRequest): Boolean // <-- ADD THIS
+    suspend fun updateReseller(userId: String, request: ResellerUpdateRequest): Boolean
 
     /**
      * Deletes a user with the RESELLER role.
      * Note: This will also delete their associated profile due to DB constraints.
      * @return True if the deletion was successful, false otherwise.
      */
-    suspend fun deleteReseller(userId: String): Boolean // <-- ADD THIS
+    suspend fun deleteReseller(userId: String): Boolean
 
     /**
      * Finds an active reseller by their unique store slug.
      * @return The User object, or null if no active reseller is found with that slug.
      */
-    suspend fun findActiveResellerBySlug(slug: String): User? // <-- ADD THIS
+    suspend fun findActiveResellerBySlug(slug: String): User?
 
+    /**
+     * Calculates and retrieves the dashboard statistics for a given reseller.
+     * @return A ResellerDashboardResponse object with the calculated data.
+     */
+    suspend fun getResellerDashboard(userId: String): ResellerDashboardResponse?
 }

--- a/src/main/kotlin/routes/resellerRouting.kt
+++ b/src/main/kotlin/routes/resellerRouting.kt
@@ -116,6 +116,19 @@ fun Route.resellerRouting() {
 
                 call.respond(response)
             }
+
+            /**
+             * GET /reseller/me/dashboard - Get the authenticated reseller's dashboard stats
+             */
+            get("/dashboard") {
+                val principal = call.principal<JWTPrincipal>()!!
+                val userId = principal.getClaim("userId", String::class)!!
+
+                val dashboardData = repository.getResellerDashboard(userId)
+                    ?: throw NotFoundException("Could not generate dashboard for the current reseller.")
+
+                call.respond(dashboardData)
+            }
         }
     }
 }


### PR DESCRIPTION
This commit introduces the commission dashboard for authenticated resellers, a key feature of the Phase 3 roadmap. It provides resellers with a comprehensive summary of their sales performance and earnings.

- **API Layer:**
  - A new, role-protected endpoint `GET /reseller/me/dashboard` is created within `resellerRouting.kt`. Access is restricted to users with the `RESELLER` role.

- **Repository Layer:**
  - A new `getResellerDashboard` method is added to the `ResellerRepository`.
  - This method performs several aggregate database queries to calculate:
    - Lifetime sales value and total commission earned for `PAID` orders.
    - Sales and commission totals for the current calendar month.
    - A list of the 5 most recent orders for a quick summary.

- **Data Models:**
  - New response DTOs, `ResellerDashboardResponse` and `SimpleOrderSummary`, are created to provide a clear and structured API contract for the dashboard data.