### PR TITLE
feat(reseller): Implement basic customer CRM feature

### DIFF
--- a/src/main/kotlin/data/model/ResellerCustomer.kt
+++ b/src/main/kotlin/data/model/ResellerCustomer.kt
@@ -1,0 +1,15 @@
+package data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a customer's information from the perspective of a reseller.
+ */
+@Serializable
+data class ResellerCustomer(
+    val customerId: String,
+    val customerName: String,
+    val customerEmail: String,
+    val firstPurchaseDate: Long,
+    val totalSpent: Double
+)

--- a/src/main/kotlin/data/repository/ResellerRepository.kt
+++ b/src/main/kotlin/data/repository/ResellerRepository.kt
@@ -2,6 +2,7 @@ package data.repository
 
 import com.example.data.model.User
 import data.model.ResellerCreateRequest
+import data.model.ResellerCustomer
 import data.model.ResellerDashboardResponse
 import data.model.ResellerUpdateRequest
 
@@ -47,4 +48,10 @@ interface ResellerRepository {
      * @return A ResellerDashboardResponse object with the calculated data.
      */
     suspend fun getResellerDashboard(userId: String): ResellerDashboardResponse?
+
+    /**
+     * Retrieves a list of customers who have purchased through the given reseller.
+     * @return A list of ResellerCustomer objects.
+     */
+    suspend fun getCustomersForReseller(resellerId: String): List<ResellerCustomer>
 }


### PR DESCRIPTION
This commit introduces the basic Customer Relationship Management (CRM) feature for resellers, as specified in the Phase 3 roadmap. Authenticated resellers can now retrieve a list of customers who have made purchases through their store link.

- **API Layer:**
  - A new, role-protected endpoint `GET /reseller/me/customers` is created in `resellerRouting.kt`. Access is restricted to users with the `RESELLER` role.

- **Repository Layer:**
  - A new `getCustomersForReseller` method is added to the `ResellerRepository`.
  - This method performs an aggregate query, joining the `orders` and `users` tables, to calculate the total amount spent and the first purchase date for each of the reseller's customers.
  - The implementation uses modern Exposed syntax (`.selectAll().where {}`).

- **Data Models:**
  - A new `ResellerCustomer` DTO is created to define a clear API contract for the customer list, providing a summary of each customer's purchase history.