### PR TITLE
feat(marketing): Implement marketing resources module

### DIFF
--- a/src/main/kotlin/Application.kt
+++ b/src/main/kotlin/Application.kt
@@ -18,6 +18,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.server.plugins.cors.routing.*
 import routes.couponRouting
+import routes.marketingRouting
 import routes.questionRouting
 import routes.resellerRouting
 import routes.reviewRouting
@@ -103,5 +104,6 @@ fun Application.module() {
         wishlistRouting()
         couponRouting()
         resellerRouting()
+        marketingRouting()
     }
 }

--- a/src/main/kotlin/data/model/MarketingMaterial.kt
+++ b/src/main/kotlin/data/model/MarketingMaterial.kt
@@ -1,0 +1,28 @@
+package data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a marketing resource provided to resellers.
+ */
+@Serializable
+data class MarketingMaterial(
+    val id: String,
+    val title: String,
+    val description: String?,
+    val assetUrl: String,
+    val assetType: String,
+    val dateAdded: Long
+)
+
+/**
+ * Represents the request body for an admin creating a new marketing resource.
+ * For now, we assume the admin provides a direct URL to the asset.
+ */
+@Serializable
+data class MarketingMaterialRequest(
+    val title: String,
+    val description: String?,
+    val assetUrl: String,
+    val assetType: String // e.g., 'IMAGE', 'BANNER', 'PDF'
+)

--- a/src/main/kotlin/data/model/Tables.kt
+++ b/src/main/kotlin/data/model/Tables.kt
@@ -190,3 +190,15 @@ object ResellerProfilesTable : Table("reseller_profiles") {
 
     override val primaryKey = PrimaryKey(userId)
 }
+
+
+object MarketingMaterialsTable : Table("marketing_materials") {
+    val id = varchar("id", 128)
+    val title = varchar("title", 255)
+    val description = text("description").nullable()
+    val assetUrl = varchar("asset_url", 1024)
+    val assetType = varchar("asset_type", 50)
+    val dateAdded = long("date_added")
+
+    override val primaryKey = PrimaryKey(id)
+}

--- a/src/main/kotlin/data/repository/MarketingRepository.kt
+++ b/src/main/kotlin/data/repository/MarketingRepository.kt
@@ -1,0 +1,21 @@
+package data.repository
+
+import data.model.MarketingMaterial
+import data.model.MarketingMaterialRequest
+
+interface MarketingRepository {
+    /**
+     * Retrieves all available marketing materials.
+     */
+    suspend fun getAllMaterials(): List<MarketingMaterial>
+
+    /**
+     * Adds a new marketing material to the database.
+     */
+    suspend fun addMaterial(request: MarketingMaterialRequest): MarketingMaterial
+
+    /**
+     * Deletes a marketing material by its ID.
+     */
+    suspend fun deleteMaterial(id: String): Boolean
+}

--- a/src/main/kotlin/data/repository/MarketingRepositoryImpl.kt
+++ b/src/main/kotlin/data/repository/MarketingRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package data.repository
+
+import com.example.data.model.MarketingMaterialsTable
+import com.example.plugins.DatabaseFactory.dbQuery
+import data.model.MarketingMaterial
+import data.model.MarketingMaterialRequest
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import java.util.*
+
+class MarketingRepositoryImpl : MarketingRepository {
+
+    private fun resultRowToMarketingMaterial(row: ResultRow) = MarketingMaterial(
+        id = row[MarketingMaterialsTable.id],
+        title = row[MarketingMaterialsTable.title],
+        description = row[MarketingMaterialsTable.description],
+        assetUrl = row[MarketingMaterialsTable.assetUrl],
+        assetType = row[MarketingMaterialsTable.assetType],
+        dateAdded = row[MarketingMaterialsTable.dateAdded]
+    )
+
+    override suspend fun getAllMaterials(): List<MarketingMaterial> = dbQuery {
+        MarketingMaterialsTable.selectAll().map(::resultRowToMarketingMaterial)
+    }
+
+    override suspend fun addMaterial(request: MarketingMaterialRequest): MarketingMaterial {
+        val newId = UUID.randomUUID().toString()
+        return dbQuery {
+            MarketingMaterialsTable.insert {
+                it[id] = newId
+                it[title] = request.title
+                it[description] = request.description
+                it[assetUrl] = request.assetUrl
+                it[assetType] = request.assetType
+                it[dateAdded] = System.currentTimeMillis()
+            }.resultedValues!!.first().let(::resultRowToMarketingMaterial)
+        }
+    }
+
+    override suspend fun deleteMaterial(id: String): Boolean = dbQuery {
+        MarketingMaterialsTable.deleteWhere { MarketingMaterialsTable.id eq id } > 0
+    }
+}

--- a/src/main/kotlin/di/KoinModule.kt
+++ b/src/main/kotlin/di/KoinModule.kt
@@ -5,6 +5,8 @@ import data.repository.AddressRepository
 import data.repository.AddressRepositoryImpl
 import data.repository.CouponRepository
 import data.repository.CouponRepositoryImpl
+import data.repository.MarketingRepository
+import data.repository.MarketingRepositoryImpl
 import data.repository.QuestionRepository
 import data.repository.QuestionRepositoryImpl
 import data.repository.ResellerRepository
@@ -37,4 +39,5 @@ val appModule = module {
     single<CouponRepository> { CouponRepositoryImpl() }
     single<WishlistRepository> { WishlistRepositoryImpl() }
     single<ResellerRepository> { ResellerRepositoryImpl(get()) }
+    single<MarketingRepository> { MarketingRepositoryImpl() }
 }

--- a/src/main/kotlin/routes/marketingRouting.kt
+++ b/src/main/kotlin/routes/marketingRouting.kt
@@ -1,0 +1,60 @@
+package routes
+
+import com.example.plugins.BadRequestException
+import com.example.plugins.NotFoundException
+import data.model.MarketingMaterialRequest
+import data.repository.MarketingRepository
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.auth.jwt.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import org.koin.ktor.ext.inject
+
+fun Route.marketingRouting() {
+    val repository: MarketingRepository by inject()
+
+    authenticate("auth-jwt") {
+        // Endpoint for Resellers to view resources
+        route("/reseller/me/resources") {
+            get {
+                val principal = call.principal<JWTPrincipal>()!!
+                if (principal.getClaim("role", String::class) != "RESELLER") {
+                    call.respond(HttpStatusCode.Forbidden, "Reseller role required.")
+                    return@get
+                }
+                val materials = repository.getAllMaterials()
+                call.respond(materials)
+            }
+        }
+
+        // Endpoints for Admins to manage resources
+        route("/admin/resources") {
+            intercept(ApplicationCallPipeline.Call) {
+                val principal = call.principal<JWTPrincipal>()
+                if (principal?.getClaim("role", String::class) != "ADMIN") {
+                    call.respond(HttpStatusCode.Forbidden, "Administrator role required.")
+                    return@intercept finish()
+                }
+            }
+
+            post {
+                val request = call.receive<MarketingMaterialRequest>()
+                val newMaterial = repository.addMaterial(request)
+                call.respond(HttpStatusCode.Created, newMaterial)
+            }
+
+            delete("{id}") {
+                val id = call.parameters["id"] ?: throw BadRequestException("Resource ID is missing.")
+                val deleted = repository.deleteMaterial(id)
+                if (deleted) {
+                    call.respond(HttpStatusCode.NoContent)
+                } else {
+                    throw NotFoundException("Resource with ID $id not found.")
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/db/migration/V12__Create_Marketing_Materials_Table.sql
+++ b/src/main/resources/db/migration/V12__Create_Marketing_Materials_Table.sql
@@ -1,0 +1,11 @@
+-- V12__Create_Marketing_Materials_Table.sql
+-- Creates a table to store links to marketing resources for resellers.
+
+CREATE TABLE marketing_materials (
+                                     id VARCHAR(128) PRIMARY KEY,
+                                     title VARCHAR(255) NOT NULL,
+                                     description TEXT,
+                                     asset_url VARCHAR(1024) NOT NULL, -- The direct URL to the image, PDF, etc.
+                                     asset_type VARCHAR(50) NOT NULL,  -- e.g., 'IMAGE', 'BANNER', 'PDF'
+                                     date_added BIGINT NOT NULL
+);


### PR DESCRIPTION
This commit introduces the "Marketing Resources" feature, the final core component of the Phase 3 reseller platform. This module allows administrators to manage marketing materials and makes them available to authenticated resellers.

- **API Layer:**
  - A new `marketingRouting.kt` file establishes two sets of role-protected endpoints:
    - `GET /reseller/me/resources` for resellers to view available materials.
    - `POST` and `DELETE` under `/admin/resources` for administrators to create and delete materials.

- **Repository Layer:**
  - A new `MarketingRepository` is created to encapsulate all database logic for the `marketing_materials` table, including adding, deleting, and retrieving all resources.

- **Database & Data Models:**
  - A new `marketing_materials` table is added via the `V12__...` Flyway migration to store asset details.
  - `MarketingMaterial` and `MarketingMaterialRequest` DTOs are created to define the API contract.
  - The `MarketingMaterialsTable` object is added for Exposed integration.

- **Configuration:**
  - The new repository is registered in the Koin DI module, and the new routes are activated in `Application.kt`.